### PR TITLE
MATRIX-702: Reinstate old method of enabling Keywords button as a backup for Select2-based method

### DIFF
--- a/Plugins/MatrixKeywordsPlugin/MatrixKeywordsPlugin.js
+++ b/Plugins/MatrixKeywordsPlugin/MatrixKeywordsPlugin.js
@@ -99,7 +99,22 @@
 					var selectField = tools.getItem(prefix + ':insertKeywordSelect');
 					var select = document.getElementById(keywordSelectorElement);
 					tools.getItem(prefix + ':insertKeywordSelect').setHtml(select);
-				} 
+				} else {
+					// Select2 isn't available (such as in Edit+). Go back to the
+					// old method, using the data-keywords array.
+					var datasetKeywords = ViperUtil.$(editableElement).data('keywords');
+					if (typeof datasetKeywords !== 'undefined' && datasetKeywords !== '') {
+						// make sure it's valid JSON associative array, not an array object.
+						if (typeof datasetKeywords.length === 'undefined') {
+							// enable button and insert those keywords as options
+							tools.enableButton('insertKeywords');
+							var selectField  = tools.getItem(prefix + ':insertKeywordSelect');
+							if (selectField.getValue() === null) {
+								tools.getItem(prefix + ':insertKeywordSelect').setValue(datasetKeywords);
+							}
+						}
+					}
+				}
 				
 				// get snippet for current div
 				var datasetSnippets = ViperUtil.$(editableElement).data('snippets');
@@ -109,7 +124,20 @@
 					var selectField = tools.getItem(prefix + ':insertSnippetSelect');
 					var select = document.getElementById(snippetSelectorElement);
 					tools.getItem(prefix + ':insertSnippetSelect').setHtml(select);
-				} 
+				} else {
+					// Select2 not available.
+					var datasetSnippets = ViperUtil.$(editableElement).data('snippets');
+					if (typeof datasetSnippets !== 'undefined' && datasetSnippets !== '') {
+						if (typeof datasetSnippets.length === 'undefined') {
+							// enable button and insert those snippets as options
+							tools.enableButton('insertSnippets');
+							var selectField  = tools.getItem(prefix + ':insertSnippetSelect');
+							if (selectField.getValue() === null) {
+								tools.getItem(prefix + ':insertSnippetSelect').setValue(datasetSnippets);
+							}
+						}
+					}
+				}
 			});
 
 			/** Fix for an issue where clicking on the Select2 scrollbar was 


### PR DESCRIPTION
https://jira.squiz.net/browse/MATRIX-702

Only applicable to the Matrix/Edit+ fork of Viper.

The way of determining whether to enable the Insert Keywords and Snippets buttons was changed so that new Select2-based select boxes can be used. But these currently require specific code in the WYSIWYG content type and attribute, and therefore aren't available in Edit+.

In Edit+, Bodycopy Manager provides a backup for assets that contain a bodycopy but it doesn't work all the time, and totally misses assets which use a WYSIWYG attribute like Calendar Event and News Item.

I'm reinstating the old method of enabling the Keywords and Snippets button - based on the "data-keywords" and "data-snippets" attributes of the editable element - as a backup to the Select2-based method, so that Edit+ can continue to use that.